### PR TITLE
Add shim to correct test seed data types in Snowflake

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -64,10 +64,10 @@ vars:
 seeds:
   dbt_fullstory_integration_tests:
     +enabled: true
-    +alias: "{% if target.type == 'snowflake' %}fullstory_events_integration_tests_raw{% endif %}"
 
-    # Override column types on all
-    +column_types:
-      event_time: datetime
-      processed_time: datetime
-      updated_time: datetime
+    fullstory_events_integration_tests:
+      +alias: "{% if target.type == 'snowflake' %}fullstory_events_integration_tests_raw{% endif %}"
+      +column_types:
+        event_time: datetime
+        processed_time: datetime
+        updated_time: datetime

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -29,6 +29,7 @@ models:
     relation: true
 
 vars:
+  events_table: fullstory_events_integration_tests
   dbt_date:time_zone: Etc/UTC
   fullstory_replay_host: app.fullstory.com
   fullstory_events_types:
@@ -63,6 +64,7 @@ vars:
 seeds:
   dbt_fullstory_integration_tests:
     +enabled: true
+    +alias: "{% if target.type == 'snowflake' %}fullstory_events_integration_tests_raw{% endif %}"
 
     # Override column types on all
     +column_types:

--- a/integration_tests/models/_snowflake_events_shim.yml
+++ b/integration_tests/models/_snowflake_events_shim.yml
@@ -1,0 +1,7 @@
+version: 2
+
+models:
+  - name: snowflake_events_shim
+    config:
+      enabled: "{{ (target.type == 'snowflake') | as_bool }}"
+      alias: fullstory_events_integration_tests

--- a/integration_tests/models/snowflake_events_shim.sql
+++ b/integration_tests/models/snowflake_events_shim.sql
@@ -1,0 +1,13 @@
+select
+  event_id,
+  event_time,
+  processed_time,
+  updated_time,
+  device_id,
+  session_id,
+  view_id,
+  event_type,
+  parse_json(event_properties) as event_properties,
+  source_type,
+  parse_json(source_properties) as source_properties
+from {{ ref('fullstory_events_integration_tests') }}

--- a/models/staging/_events__sources.yml
+++ b/models/staging/_events__sources.yml
@@ -7,7 +7,7 @@ sources:
     tables:
       - name: events
         description: The FullStory events table.
-        identifier: "{% if target.type == 'bigquery' %}fullstory_events_{{ modules.re.sub('[^a-zA-Z\\d_\\-]', '_', target.name) }}{% else %}events{% endif %}"
+        identifier: "{% if var('events_table', '') %}{{ var('events_table') }}{% else %}{% if target.type == 'bigquery' %}fullstory_events_{{ modules.re.sub('[^a-zA-Z\\d_\\-]', '_', target.name) }}{% else %}events{% endif %}{% endif %}"
         columns:
           - name: event_id
           - name: device_id


### PR DESCRIPTION
## Problem
The Snowflake schema uses the `variant` data type for the JSON columns `event_properties` and `source_properties`. However, dbt interprets these columns as `varchar`, and explicitly setting the column data type in the seed configuration results in an error.

## Changes
- Provide a variable to override the table name and set it explicitly in the `integration_tests` package so that all models target the same identifier.
- Add a shim model that is only deployed when `target.type == 'snowflake'`. The shim uses `parse_json` to convert JSON columns to `variant`.
- Alias the `fullstory_events_integration_tests` to `fullstory_events_integration_tests_raw` when `target.type == 'snowflake'`

The result is that, in Snowflake, all views are built on top of the shim view instead of the physical seed table. Other target types are unaffected.