### PR TITLE
use incremental models to save time / money

### DIFF
--- a/models/sessions__ordered.sql
+++ b/models/sessions__ordered.sql
@@ -1,0 +1,15 @@
+-- This model exists as a way to sequence the sessions in order for a user. The desc_row_num
+-- column cannot be part of a materialized table because of late arriving events.
+-- Example: We have a session for user id 'alice' with a desc_row_num of 1. On the next incremental
+-- run, we get another new session. `desc_row_num` would be calculated as 1 again, and now we would
+-- have two sessions with `desc_row_num = 1`. This would cause down stream tables to fail since
+-- we typically look for a single row where `desc_row_num = 1` to display the latest data.
+select
+  *,
+  row_number() over (
+    partition by user_id
+    order by
+        end_time desc,
+        full_session_id desc
+  ) as desc_row_num
+from {{ ref('sessions') }}

--- a/models/sessions__ordered.sql
+++ b/models/sessions__ordered.sql
@@ -1,9 +1,12 @@
 -- This model exists as a way to sequence the sessions in order for a user. The desc_row_num
 -- column cannot be part of a materialized table because of late arriving events.
 -- Example: We have a session for user id 'alice' with a desc_row_num of 1. On the next incremental
--- run, we get another new session. `desc_row_num` would be calculated as 1 again, and now we would
--- have two sessions with `desc_row_num = 1`. This would cause down stream tables to fail since
--- we typically look for a single row where `desc_row_num = 1` to display the latest data.
+-- run, we get another new session. `desc_row_num` could be calculated as 1 again, and now we would
+-- have two sessions with `desc_row_num = 1` in the incremental table. This would cause down stream
+-- incremental tables to fail with the error: UPDATE/MERGE must match at most one source row for
+-- each target row.
+-- By using a view, we can be sure that `desc_row_num` is always accurate, even if it comes at a
+-- performance cost.
 select
   *,
   row_number() over (

--- a/models/staging/stg_events__all.sql
+++ b/models/staging/stg_events__all.sql
@@ -1,6 +1,7 @@
 {{
     config(
         materialized='incremental',
+        unique_key='event_id',
         partition_by={
             "field": "updated_time",
             "data_type": "timestamp",


### PR DESCRIPTION
This changes our highly used models to the materialization type `incremental` so that we only update rows that need to be updated when new data comes in.

In order to make this efficient, I had to change `stg_events__all` to also be incremental and add some partitioning / clustering logic. This change alone makes the life of all the down stream tables much easier.

Now `users`, and `sessions` are incrementally loaded which results in a _dramatic_ decrease of processed bytes for each dbt run. Internally, I have measured this at a > 99% reduction in the amount of processing required to load new data.