### PR TITLE
prefix all vars with fullstory, add descriptions to README, general hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ This dbt package contains models, macros, seeds, and tests for [FullStory](https
 ## Vars
 | var | description |
 | - | - |
-| fullstory_events_database | The database where your raw events table lives. |
-| fullstory_events_schema | The schema inside of your database where your raw events table lives. |
-| fullstory_events_table | The name of the table inside your schema where your raw events table lives. |
+| fullstory_events_database | The database where your FullStory events table lives. |
+| fullstory_events_schema | The schema inside of your database where your FullStory events table lives. |
+| fullstory_events_table | The name of the table inside your schema where your FullStory events table lives. |
 | fullstory_replay_host | The hostname to use when building links to session replay. |
 | fullstory_sessions_model_name | The name of the model for the canonical list of sessions. |
 | fullstory_users_model_name | The name of the model for the canonical list of users. |
 | fullstory_min_event_time | All events before this date will not be considered for analysis. Use this option to limit table size. |
 | fullstory_event_types | A list of event types to auto-generate rollups for in the `users` and `sessions` model. |
 
-> We **highly recommend** using `fullstory_events_database`, `fullstory_events_schema` and `fullstory_events_table` to indicate the location of the raw events table that is synced from Data Destinations. Using these variables allow you to use a separate database or schema for the raw events table than your dbt package.
+> We **highly recommend** using `fullstory_events_database`, `fullstory_events_schema` and `fullstory_events_table` to indicate the location of the FullStory events table that is synced from Data Destinations. Using these variables allow you to use a separate database or schema for the FullStory events table than your dbt package.
 
 #### Example use of vars for Big Query
 ```yaml
@@ -27,6 +27,14 @@ vars:
   fullstory_events_database: my-gcp-project
   fullstory_events_schema: my-big-query-dataset
   fullstory_events_table: fullstory_events_[my-org-id]
+```
+
+#### Example use of vars for Snowflake
+```yaml
+vars:
+  fullstory_events_database: my_database
+  fullstory_events_schema: my_schema
+  fullstory_events_table: my_table
 ```
 
 ## Supported Warehouses

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ This dbt package contains models, macros, seeds, and tests for [FullStory](https
 | sessions | Session-level aggregations, including event counts broken down by type, location and device information, duration, FullStory session replay links, etc.
 | users | User-level aggregations, including email addresses, location and device information, session counts, etc.
 
+## Vars
+| var | description |
+| - | - |
+| fullstory_events_database | The database where your raw events table lives. |
+| fullstory_events_schema | The schema inside of your database where your raw events table lives. |
+| fullstory_events_table | The name of the table inside your schema where your raw events table lives. |
+| fullstory_replay_host | The hostname to use when building links to session replay. |
+| fullstory_sessions_model_name | The name of the model for the canonical list of sessions. |
+| fullstory_users_model_name | The name of the model for the canonical list of users. |
+| fullstory_min_event_time | All events before this date will not be considered for analysis. Use this option to limit table size. |
+| fullstory_event_types | A list of event types to auto-generate rollups for in the `users` and `sessions` model. |
+
 ## Supported Warehouses
 - BigQuery
 - Snowflake

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "dbt_fullstory"
 version: "0.1.0"
 config-version: 2
-require-dbt-version: [">=1.2.0", "<2.0.0"]
+require-dbt-version: [">=1.6.0", "<2.0.0"]
 
 # This setting configures which "profile" dbt uses for this project.
 profile: "dbt_fullstory"

--- a/models/_session_models.yml
+++ b/models/_session_models.yml
@@ -423,7 +423,7 @@ models:
   - name: sessions
     access: public
     config:
-      alias: "{% if var('sessions_identifier', '') %}{{ var('sessions_identifier') }}{% else %}{% if target.type == 'bigquery' %}fullstory_sessions_{{ modules.re.sub('[^a-zA-Z\\d_\\-]', '_', target.name) }}{% else %}sessions{% endif %}{% endif %}"
+      alias: "{% if var('fullstory_sessions_model_name', '') %}{{ var('fullstory_sessions_model_name') }}{% else %}{% if target.type == 'bigquery' %}fullstory_sessions_{{ modules.re.sub('[^a-zA-Z\\d_\\-]', '_', target.name) }}{% else %}sessions{% endif %}{% endif %}"
       contract:
         enforce: true
     description: |-

--- a/models/_user_models.yml
+++ b/models/_user_models.yml
@@ -376,7 +376,7 @@ models:
   - name: users
     access: public
     config:
-      alias: "{% if var('users_identifier', '') %}{{ var('users_identifier') }}{% else %}{% if target.type == 'bigquery' %}fullstory_users_{{ modules.re.sub('[^a-zA-Z\\d_\\-]', '_', target.name) }}{% else %}users{% endif %}{% endif %}"
+      alias: "{% if var('fullstory_users_model_name', '') %}{{ var('fullstory_users_model_name') }}{% else %}{% if target.type == 'bigquery' %}fullstory_users_{{ modules.re.sub('[^a-zA-Z\\d_\\-]', '_', target.name) }}{% else %}users{% endif %}{% endif %}"
       contract:
         enforce: true
     description: |-

--- a/models/staging/_events__sources.yml
+++ b/models/staging/_events__sources.yml
@@ -2,12 +2,12 @@ version: 2
 
 sources:
   - name: fullstory
-    database: "{{ target.database }}"
-    schema: "{{ target.schema or target.dataset}}"
+    database: "{{ var('fullstory_events_database', target.database) }}"
+    schema: "{{ var('fullstory_events_schema', target.schema or target.dataset) }}"
     tables:
       - name: events
         description: The FullStory events table.
-        identifier: "{% if var('events_table', '') %}{{ var('events_table') }}{% else %}{% if target.type == 'bigquery' %}fullstory_events_{{ modules.re.sub('[^a-zA-Z\\d_\\-]', '_', target.name) }}{% else %}events{% endif %}{% endif %}"
+        identifier: "{% if var('fullstory_events_table', '') %}{{ var('fullstory_events_table') }}{% else %}{% if target.type == 'bigquery' %}fullstory_events_{{ modules.re.sub('[^a-zA-Z\\d_\\-]', '_', target.name) }}{% else %}events{% endif %}{% endif %}"
         columns:
           - name: event_id
           - name: device_id


### PR DESCRIPTION
A couple things here:
1. Prefixing all of our vars with the standard `fullstory_` will make sure that our vars will not collide with any other DBT package.
2. When using this DBT package, I found it necessary to be able to provide the database, schema and table name explicitly so that we don't need to run the consuming DBT project in the same dataset as the raw events table. To support this,  I introduced: `fullstory_events_database`, `fullstory_events_schema` and `fullstory_events_table`. This allows us to sync the events table once using Data Destinations, then use the same table across many projects or datasets (Big Query).
3. Updated variable names to be more consistent / better indicate their purpose.

@craigrmccown this also addresses feedback [here](https://github.com/dbt-labs/hubcap/pull/281#pullrequestreview-1619059947).