### PR TITLE
parse json before querying, output json column types

### DIFF
--- a/integration_tests/models/_test_events.yml
+++ b/integration_tests/models/_test_events.yml
@@ -199,7 +199,7 @@ models:
           config:
             where: event_id = 'user_total_sessions_test_3'
       - dbt_utils.expression_is_true:
-          name: user_properties_is_correct
-          expression: "{{ dbt_fullstory.json_value('user_properties', '$.good_key') }} = 'good_value'"
+          name: user_properties_are_correct
+          expression: "{{ dbt_fullstory.json_value('user_properties', '$.good_key', skip_parse=True) }} = 'good_value'"
           config:
             where: event_id = 'user_total_sessions_test_3'

--- a/integration_tests/models/_test_identified_users.yml
+++ b/integration_tests/models/_test_identified_users.yml
@@ -15,7 +15,7 @@ models:
             where: user_id = 'good_user_id'
       - dbt_utils.expression_is_true:
           name: user_properties_are_correct
-          expression: "{{ dbt_fullstory.json_value('user_properties', '$.good_key') }} = 'good_value'"
+          expression: "{{ dbt_fullstory.json_value('user_properties', '$.good_key', skip_parse=True) }} = 'good_value'"
           config:
             where: user_id = 'good_user_id'
       - dbt_utils.expression_is_true:

--- a/integration_tests/models/_test_identifies.yml
+++ b/integration_tests/models/_test_identifies.yml
@@ -55,6 +55,6 @@ models:
             where: event_id = 'identify_session_test_6'
       - dbt_utils.expression_is_true:
           name: user_properties_are_correct
-          expression: "{{ dbt_fullstory.json_value('user_properties', '$.good_key') }} = 'good_value'"
+          expression: "{{ dbt_fullstory.json_value('user_properties', '$.good_key', skip_parse=True) }} = 'good_value'"
           config:
             where: event_id = 'identify_session_test_6'

--- a/integration_tests/seeds/fullstory_events_integration_seeds.csv
+++ b/integration_tests/seeds/fullstory_events_integration_seeds.csv
@@ -75,7 +75,7 @@ session_anonymous_user_id_test_2,2023-01-01 13:00:01,2023-01-01 12:00:00,2023-01
 user_total_sessions_test_1,2023-01-01 13:00:00,2023-01-01 12:00:00,2023-01-01 00:00:00,10,1,1,identify,"{""user_id"":""user_test_total_sessions_user_id""}",web,{}
 user_total_sessions_test_4,2023-01-01 13:00:05,2023-01-01 12:00:00,2023-01-01 00:00:00,10,1,1,click,{},web,{}
 user_total_sessions_test_2,2023-01-01 13:01:00,2023-01-01 12:00:00,2023-01-01 00:00:00,10,2,1,identify,"{""user_id"":""user_test_total_sessions_user_id""}",web,{}
-user_total_sessions_test_3,2023-01-01 13:01:00,2023-01-01 12:00:00,2023-01-01 00:00:00,11,1,1,identify,"{""user_id"":""user_test_total_sessions_user_id"",""user_email"":""good_user@fullstory.com"",""user_display_name"":""good_display_name"",""user_properites"":{""good_key"":""good_value""}}",mobile_app,{}
+user_total_sessions_test_3,2023-01-01 13:01:00,2023-01-01 12:00:00,2023-01-01 00:00:00,11,1,1,identify,"{""user_id"":""user_test_total_sessions_user_id"",""user_email"":""good_user@fullstory.com"",""user_display_name"":""good_display_name"",""user_properties"":{""good_key"":""good_value""}}",mobile_app,{}
 user_total_sessions_test_5,2023-01-01 13:01:05,2023-01-01 12:00:00,2023-01-01 00:00:00,11,1,1,click,{},mobile_app,{}
 session_device_identify_user_test_1,2023-01-01 13:00:00,2023-01-01 12:00:00,2023-01-01 00:00:00,12,1,1,load,{},web,{}
 session_device_identify_user_test_2,2023-01-01 13:00:05,2023-01-01 12:00:00,2023-01-01 00:00:00,12,1,1,click,{},web,{}

--- a/macros/json_value.sql
+++ b/macros/json_value.sql
@@ -5,7 +5,8 @@
 {%- macro default__json_value(column, path, array, dtype, skip_parse) -%}
 {# We need to parse the json if we don't explicitly skip it. #}
 {%- if not skip_parse -%}
-{%- set column = 'PARSE_JSON(' + column +')' -%}
+{# We should round big numbers so that they can be round-tripped from string > double > string. #}
+{%- set column = "PARSE_JSON(" + column +",wide_number_mode=>'round')" -%}
 {%- endif %}
 
 {%- if array -%}


### PR DESCRIPTION
This modifies the `json_value` macro to parse the JSON before attempting to extract a value. This causes the native `JSON_QUERY` function to return a column of `JSON` type instead of `STRING` which creates a better interface for users.

In short, now customers can query our `event_properties`, `source_properties` and `user_properties` using dot notation in BigQuery. Snowflake is unaffected.
```sql
SELECT
     user_properties.my_custom_property
FROM events;
```
instead of
```sql
SELECT
   JSON_QUERY(user_properties, '$.my_custom_property')
FROM events;
```

When the events table is built incrementally and this is persisted, it may enable some better performance by BigQuery since it's now aware the column is JSON (compression, etc).