### PR TITLE
handle extracting root using json_value

### DIFF
--- a/macros/json_value.sql
+++ b/macros/json_value.sql
@@ -20,7 +20,7 @@
 
 {%- macro snowflake__json_value(column, path, array, dtype, skip_parse) -%}
   {# Remove the leading $. from the path #}
-  {% set path = modules.re.sub('\$\.', '', path) %}
+  {% set path = modules.re.sub('\$\.?', '', path) %}
   {# Replace dots with colons in the path #}
   {% set path = modules.re.sub('\.', ':', path) %}
   {{column}}:{{path}}

--- a/macros/json_value.sql
+++ b/macros/json_value.sql
@@ -20,8 +20,12 @@
 
 {%- macro snowflake__json_value(column, path, array, dtype, skip_parse) -%}
   {# Remove the leading $. from the path #}
-  {% set path = modules.re.sub('\$\.?', '', path) %}
+  {%- set path = modules.re.sub('\$\.?', '', path) -%}
   {# Replace dots with colons in the path #}
-  {% set path = modules.re.sub('\.', ':', path) %}
-  {{column}}:{{path}}
+  {%- set path = modules.re.sub('\.', ':', path) -%}
+  {# If there is a path, prefix with a colon #}
+  {%- if path != '' -%}
+  {%- set path = ':' + path -%}
+  {%- endif -%}
+  {{column}}{{path}}
 {%- endmacro -%}

--- a/tests/json_value_child.sql
+++ b/tests/json_value_child.sql
@@ -1,5 +1,5 @@
 with x as (
-  select '{"good_key":"good_value"}' as col
+  select PARSE_JSON('{"good_key":"good_value"}') as col
 )
 select *
 from x

--- a/tests/json_value_child.sql
+++ b/tests/json_value_child.sql
@@ -1,5 +1,9 @@
 with x as (
+  {%- if target.type == 'snowflake' -%}
   select PARSE_JSON('{"good_key":"good_value"}') as col
+  {%- else -%}
+  select '{"good_key":"good_value"}' as col
+  {%- endif -%}
 )
 select *
 from x

--- a/tests/json_value_child.sql
+++ b/tests/json_value_child.sql
@@ -1,0 +1,6 @@
+with x as (
+  select '{"good_key":"good_value"}' as col
+)
+select *
+from x
+where {{ json_value("col", "$.good_key") }} != 'good_value'

--- a/tests/json_value_root.sql
+++ b/tests/json_value_root.sql
@@ -1,5 +1,5 @@
 with x as (
-  select '{"good_key":"good_value"}' as col
+  select PARSE_JSON('{"good_key":"good_value"}') as col
 )
 select *
 from x

--- a/tests/json_value_root.sql
+++ b/tests/json_value_root.sql
@@ -1,5 +1,9 @@
 with x as (
+  {%- if target.type == 'snowflake' -%}
   select PARSE_JSON('{"good_key":"good_value"}') as col
+  {%- else -%}
+  select '{"good_key":"good_value"}' as col
+  {%- endif -%}
 )
 select *
 from x

--- a/tests/json_value_root.sql
+++ b/tests/json_value_root.sql
@@ -1,0 +1,6 @@
+with x as (
+  select '{"good_key":"good_value"}' as col
+)
+select *
+from x
+where {{ json_value("col", "$") }} != '{"good_key":"good_value"}'


### PR DESCRIPTION
This modifies the `json_value` function so that you can extract the entire column by simply specifying `$`. This is effectively a cross-platform JSON parse.