### PR TITLE
email is not a unique field for identified_users

### DIFF
--- a/models/identified_users.yml
+++ b/models/identified_users.yml
@@ -18,8 +18,6 @@ models:
           - unique
       - name: user_email
         description: '{{ doc("column_user_email") }}'
-        tests:
-          - unique
       - name: user_display_name
         description: '{{ doc("column_user_display_name") }}'
       - name: user_properties


### PR DESCRIPTION
This eliminates a test for uniqueness on `user_email`. The unique field in this context is `user_id`.