### PR TITLE
added course_duration to sessions model

### DIFF
--- a/models/intermediate/int_course_sessions.sql
+++ b/models/intermediate/int_course_sessions.sql
@@ -1,0 +1,30 @@
+with events_enriched as (
+    select 
+        concat(device_id, ':', session_id) as full_session_id
+        , session_id
+        , event_id
+        , event_time as event_start_time
+        , lag(event_time) over(partition by session_id order by event_time desc) as event_end_time
+        , timediff(seconds, event_start_time, event_end_time) as event_duration_seconds
+        , view_id
+        , event_type
+        , case
+            when split_part(source_properties:url:path::string, '/', 2) = 'course' then true
+            else false
+          end as is_course_event
+        , source_properties
+    from 
+        {{ ref("events") }}
+    order by
+        event_time desc
+)
+
+select
+    full_session_id
+    , sum(event_duration_seconds) as course_event_duration_seconds
+from
+    events_enriched
+where
+    is_course_event = true
+group by
+    1

--- a/models/intermediate/int_sessions.sql
+++ b/models/intermediate/int_sessions.sql
@@ -25,11 +25,15 @@ select
     count(case when events.event_type = '{{ type }}' then 1 end) as total_{{ type }}_events{% if not loop.last %},{% endif %}
     {% endfor %},
     count(case when events.source_type = 'web' then 1 end) as total_web_events,
-    count(case when events.source_type = 'mobile_app' then 1 end) as total_mobile_app_events
+    count(case when events.source_type = 'mobile_app' then 1 end) as total_mobile_app_events,
+    {{ dbt.any_value("course_sessions.event_duration_seconds") }} as course_duration,
 from {{ ref("events") }} as events
 left outer join
     {{ ref("stg_events__user_keys") }} as users on
         users.desc_row_num = 1 and
         events.device_id = users.device_id
+left join
+    {{ ref("int_course_sessions") }} course_sessions on
+        events.full_session_id = course_sessions.full_session_id
 where events.full_session_id is not null
 group by events.full_session_id

--- a/models/sessions.sql
+++ b/models/sessions.sql
@@ -32,6 +32,7 @@ select
     base.total_mobile_app_events,
     base.total_page_views,
     base.total_unique_urls,
+    base.course_duration,
     {% for type in var("fullstory_events_types") -%}
     base.total_{{ type }}_events{% if not loop.last %},{% endif %}
     {% endfor %},


### PR DESCRIPTION
Added a field called `course_duration` to the sessions model. This field shows the total number of seconds spent on a course url during the session.