### PR TITLE
add unique key for sessions

### DIFF
--- a/models/sessions.sql
+++ b/models/sessions.sql
@@ -1,3 +1,8 @@
+{{
+    config(
+        unique_key='full_session_id',
+    )
+}}
 select
     base.full_session_id,
     coalesce(base.user_id, {{ dbt.concat(["'anon_'", "base.device_id"]) }}) as user_id,


### PR DESCRIPTION
This adds a default value for unique key which will lessen customer configuration during incremental setup. This is already set for `int_sessions`.