### PR TITLE
fix incremental model, add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ jobs:
             dbt compile --target bigquery
             dbt run --target bigquery --full-refresh --select bigquery_events_shim
             dbt run --target bigquery --full-refresh
+            dbt run --target bigquery
             dbt test --target bigquery
 
   bigquery_v2_test:
@@ -158,6 +159,7 @@ jobs:
             dbt compile --target bigquery_v2 --vars '{"fullstory_skip_json_parse": true}'
             dbt run --target bigquery_v2 --full-refresh --select bigquery_v2_events_shim --vars '{"fullstory_skip_json_parse": true}'
             dbt run --target bigquery_v2 --full-refresh --vars '{"fullstory_skip_json_parse": true}'
+            dbt run --target bigquery_v2 --vars '{"fullstory_skip_json_parse": true}'
             dbt test --target bigquery_v2 --vars '{"fullstory_skip_json_parse": true}'
 
   snowflake_test:
@@ -176,6 +178,7 @@ jobs:
             dbt compile --target snowflake
             dbt run --target snowflake --full-refresh --select snowflake_events_shim
             dbt run --target snowflake --full-refresh
+            dbt run --target snowflake
             dbt test --target snowflake
 
   redshift_test:
@@ -194,6 +197,7 @@ jobs:
             dbt compile --target redshift
             dbt run --target redshift --full-refresh --select redshift_events_shim
             dbt run --target redshift --full-refresh
+            dbt run --target redshift
             dbt test --target redshift
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ DBT provides a powerful mechanism for improving the performance of your models a
 
 > If you are running DBT on a regular interval, be aware that `dbt run` will take longer to run with the incremental materialization than with a view materialization.
 
-In this package, it is important to start with the incrementalization of the `events` model, since it functions as an activity log and is an ancestor to all models in this package.
+In this package, it is important to start with the incrementalization of the `events` model, since it functions as an activity log and is an ancestor to all models in this package. If you do decide you need more incrementalization than just the events table, you should consider incrementalizing the ancestor models of your target model in order to reap the biggest benefit.
 
 ### Getting started with incremental models
 
@@ -184,9 +184,15 @@ models:
   ...
 
   dbt_fullstory: # The package name you are customizing
+    intermediate:
+      int_sessions:
+        materialized: incremental
+        +partition_by:
+          field: updated_time
+          data_type: timestamp
+          granularity: day
     events: # The model name
       materialized: incremental
-      unique_key: event_id
       # The following options are Big Query specific optimizations. For specific configuration options for your warehouse see: https://docs.getdbt.com/reference/model-configs#warehouse-specific-configurations
       +partition_by: 
         field: event_time
@@ -196,7 +202,6 @@ models:
         - device_id
     sessions: # The model name
       materialized: incremental
-      unique_key: full_session_id
       # The following options are Big Query specific optimizations. For specific configuration options for your warehouse see: https://docs.getdbt.com/reference/model-configs#warehouse-specific-configurations
       +partition_by: 
         field: updated_time

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ models:
         - user_id
 ```
 
-When loading data incrementally, DBT needs to know how far back to look in the current table for data to compare to the incoming data. We will look back 2 days for data to update by default. This interval can be configured with the variable `fullstory_incremental_interval` and should be specified as a SQL interval like `INTERVAL 2 DAY`.
+When loading data incrementally, DBT needs to know how far back to look in the current table for data to compare to the incoming data. We will look back 2 days for data to update by default. This interval can be configured with the variable `fullstory_incremental_interval_hours`.
 
 Two days was decided upon because we typically drop late arriving events after 24 hours. To understand why a event may arrive late, please check out [this article on swan songs](https://help.fullstory.com/hc/en-us/articles/360048109714-Swan-songs-How-Fullstory-captures-sessions-that-end-unexpectedly#:~:text=If%20the%20user%20navigates%20away,Fullstory%20before%20the%20page%20closes.).
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -54,7 +54,7 @@ models:
 
 vars:
   dbt_date:time_zone: Etc/UTC
-  fullstory_incremental_interval: INTERVAL 8 DAY
+  fullstory_incremental_interval_hours: 192 # 8 days
   fullstory_replay_host: app.fullstory.com
 
   # For filtering all event data, if necessary

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -60,7 +60,7 @@ vars:
       "pinch_gesture",
       "request",
     ]
-  fullstory_incremental_interval: INTERVAL '12' HOUR
+  fullstory_incremental_interval_hours: 192
   fullstory_replay_host: app.fullstory.com
 
 seeds:

--- a/models/events.sql
+++ b/models/events.sql
@@ -249,5 +249,5 @@ where
         -- we can't use the max event_time because event_time is specified by the client. We cannot guarantee
         -- that it is accurate. Instead, we will use the current timestamp, and look back a configurable
         -- distance for updates.
-        and cast(event_time as timestamp) >= current_timestamp - {{ var("fullstory_incremental_interval") }}
+        and cast(event_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
     {% endif %}

--- a/models/events.sql
+++ b/models/events.sql
@@ -246,8 +246,8 @@ where
     event_type is not null and
     event_time >= '{{ var("fullstory_min_event_time") }}'
     {% if is_incremental() %}
-        -- we can't use the max event_time because event_time is specified by the client. We cannot guarantee
-        -- that it is accurate. Instead, we will use the current timestamp, and look back a configurable
-        -- distance for updates.
-        and cast(event_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
+    -- we can't use the max event_time because event_time is specified by the client. We cannot guarantee
+    -- that it is accurate. Instead, we will use the current timestamp, and look back a configurable
+    -- distance for updates.
+    and cast(event_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
     {% endif %}

--- a/models/events.sql
+++ b/models/events.sql
@@ -249,5 +249,5 @@ where
     -- we can't use the max event_time because event_time is specified by the client. We cannot guarantee
     -- that it is accurate. Instead, we will use the current timestamp, and look back a configurable
     -- distance for updates.
-    and cast(event_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
+    and {{ dbt.cast("event_time", api.Column.translate_type("datetime")) }} >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp=dbt.current_timestamp()) }}
     {% endif %}

--- a/models/events.sql
+++ b/models/events.sql
@@ -1,3 +1,8 @@
+{{
+    config(
+        unique_key='event_id'
+    )
+}}
 select
     event_id as event_id,
     device_id,

--- a/models/intermediate/int_sessions.sql
+++ b/models/intermediate/int_sessions.sql
@@ -38,7 +38,7 @@ left outer join
         events.device_id = users.device_id
 where
     events.full_session_id is not null
-    {% if is_incremental() %}
-    and cast(events.event_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
-    {% endif %}
+    {# {% if is_incremental() %} #}
+    and {{ dbt.cast("events.event_time", api.Column.translate_type("datetime")) }} >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp=dbt.current_timestamp()) }}
+    {# {% endif %} #}
 group by events.full_session_id

--- a/models/intermediate/int_sessions.sql
+++ b/models/intermediate/int_sessions.sql
@@ -39,6 +39,6 @@ left outer join
 where
     events.full_session_id is not null
     {% if is_incremental() %}
-    and cast(events.event_time as timestamp) >= current_timestamp - {{ var("fullstory_incremental_interval") }}
+    and cast(events.event_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
     {% endif %}
 group by events.full_session_id

--- a/models/intermediate/int_sessions.sql
+++ b/models/intermediate/int_sessions.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        unique_key='full_session_id',
+        unique_key='full_session_id'
     )
 }}
 select
@@ -39,6 +39,6 @@ left outer join
 where
     events.full_session_id is not null
     {% if is_incremental() %}
-    cast(base.updated_time as timestamp) >= current_timestamp - {{ var("fullstory_incremental_interval") }}
+    and cast(events.event_time as timestamp) >= current_timestamp - {{ var("fullstory_incremental_interval") }}
     {% endif %}
 group by events.full_session_id

--- a/models/sessions.sql
+++ b/models/sessions.sql
@@ -62,5 +62,5 @@ left join
     on locations.desc_row_num = 1
     and base.full_session_id = locations.full_session_id
 {% if is_incremental() %}
-where cast(base.updated_time as timestamp) >= current_timestamp - {{ var("fullstory_incremental_interval") }}
+cast(base.updated_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
 {% endif %}

--- a/models/sessions.sql
+++ b/models/sessions.sql
@@ -63,5 +63,5 @@ left join
     and base.full_session_id = locations.full_session_id
 {% if is_incremental() %}
 where
-    cast(base.updated_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
+    {{ dbt.cast("base.updated_time", api.Column.translate_type("datetime")) }} >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp=dbt.current_timestamp()) }}
 {% endif %}

--- a/models/sessions.sql
+++ b/models/sessions.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        unique_key='full_session_id',
+        unique_key='full_session_id'
     )
 }}
 select

--- a/models/sessions.sql
+++ b/models/sessions.sql
@@ -62,5 +62,6 @@ left join
     on locations.desc_row_num = 1
     and base.full_session_id = locations.full_session_id
 {% if is_incremental() %}
-cast(base.updated_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
+where
+    cast(base.updated_time as timestamp) >= {{ dbt.dateadd(datepart="hour", interval=-1 * var("fullstory_incremental_interval_hours", 7 * 24), from_date_or_timestamp="current_timestamp") }}
 {% endif %}

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,4 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0
+sha1_hash: dd1e1feb2d2bbce79e7a255cd309a60e6548df0b

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # Python Requirements File
 
 # dbt packages
-dbt-bigquery==1.7.6
-dbt-core==1.7.15
-dbt-snowflake==1.7.2
-dbt-redshift==1.7.4
+dbt-bigquery==1.9.1
+dbt-core==1.9.1
+dbt-snowflake==1.9.1
+dbt-redshift==1.9.0
 cffi>=1.15.1,<2.0.0
 
 # Git pre-commit hooks


### PR DESCRIPTION
This fixes a syntax error that was uncovered when running in incremental mode 🤦. I added a provision to the automated tests that will now run dbt twice, once with full refresh and once in incremental mode.

I also changed to use the dbt.cast macro and dbt.dateadd macro to make things work properly across databases (uncovered with the new tests).