### PR TITLE
#45 - macro call in wrong spot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ logs/
 working/
 
 package-lock.concurrent-update-lock
+dbt_internal_packages/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2025-09-25
+- **Fix events incremental model** - Events model was not parsing its incremental loading correctly.
+
 ## [0.9.3] - 2025-07-23
 - **Add incremental model support to events** - The `events.sql` model now supports incremental loading. Please check the `README.md` file for details on how to enable incremental loading.
 

--- a/models/events.sql
+++ b/models/events.sql
@@ -17,10 +17,10 @@ with staging as (
 select
   {{ dbt_utils.star(ref('stg_fullstory__events'), except=["full_session_id_rn", "device_id_rn", "user_id_rn", "latest_user_id"]) }}
 from staging
+where event_id_rn = 1
 {% if is_incremental() %}
 and
 staging.updated_time >=  (select max(staging.updated_time) from {{ this }})  
 and
 staging.event_time >= {{ dbt.dateadd("hour", incremental_adjustment, dbt.current_timestamp()) }} 
 {% endif %}
-where event_id_rn = 1


### PR DESCRIPTION
This pull request makes a small but important change to the filtering logic in the `models/events.sql` file. The placement of the `where event_id_rn = 1` clause has been adjusted to ensure correct query execution and incremental logic.

- SQL logic update:
  * Moved the `where event_id_rn = 1` clause to appear before the incremental filters, ensuring that the row number filter is always applied regardless of whether the query is running incrementally or as a full refresh.